### PR TITLE
 feat: create livecd user and autologin for SDDM/LightDM 

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -93,20 +93,20 @@ iso:
     sudo dnf install -y grub2 grub2-efi grub2-tools-extra xorriso
     grub2-mkrescue --xorriso=/app/src/xorriso_wrapper.sh -o /app/output.iso /app/{{ isoroot }}"
 
-build image livecd_user=0:
+build image livecd_user="0":
     #!/usr/bin/env bash
     set -xeuo pipefail
     just clean
-    just initramfs "${IMAGE}"
-    just rootfs "${IMAGE}"
+    just initramfs "{{ image }}"
+    just rootfs "{{ image }}"
     just rootfs-setuid
-    just rootfs-include-container "${IMAGE}"
+    just rootfs-include-container "{{ image }}"
 
     if [[ {{ livecd_user }} == 1 ]]; then
       just copy-into-rootfs
     fi
 
-    just squash "${IMAGE}"
+    just squash "{{ image }}"
     just iso-organize
     just iso
 

--- a/Justfile
+++ b/Justfile
@@ -100,7 +100,7 @@ build image livecd_user="0":
     just initramfs "{{ image }}"
     just rootfs "{{ image }}"
     just rootfs-setuid
-    just rootfs-include-container "{{ image }}"
+    #just rootfs-include-container "{{ image }}"
 
     if [[ {{ livecd_user }} == 1 ]]; then
       just copy-into-rootfs
@@ -127,7 +127,7 @@ vm *ARGS:
         -enable-kvm \
         -M q35 \
         -cpu host \
-        -smp 1 \
+        -smp $(( $(nproc) / 2 > 0 ? $(nproc) / 2 : 1 )) \
         -m 4G \
         -net nic,model=virtio \
         -net user,hostfwd=tcp::2222-:22 \

--- a/src/system/etc/lightdm/lightdm.conf
+++ b/src/system/etc/lightdm/lightdm.conf
@@ -1,0 +1,3 @@
+[SeatDefaults]
+autologin-user=livecd
+autologin-user-timeout=0

--- a/src/system/etc/sddm.conf.d/autologin.conf
+++ b/src/system/etc/sddm.conf.d/autologin.conf
@@ -1,0 +1,3 @@
+[Autologin]
+User=livecd
+Session=plasma

--- a/src/system/etc/systemd/system/getty@tty1.service.d/autologin.conf
+++ b/src/system/etc/systemd/system/getty@tty1.service.d/autologin.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty --autologin livecd --noclear %I $TERM

--- a/src/system/etc/systemd/system/multi-user.target.wants/livecd-user.service
+++ b/src/system/etc/systemd/system/multi-user.target.wants/livecd-user.service
@@ -1,0 +1,1 @@
+/usr/lib/systemd/system/livecd-user.service

--- a/src/system/usr/lib/systemd/system/livecd-user.service
+++ b/src/system/usr/lib/systemd/system/livecd-user.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create LiveCD User
+After=network.target local-fs.target
+Before=login.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/create-livecd-user.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/src/system/usr/lib/tmpfiles.d/lightdm-autologin-override.conf
+++ b/src/system/usr/lib/tmpfiles.d/lightdm-autologin-override.conf
@@ -1,0 +1,1 @@
+r /usr/share/lightdm/lightdm.conf.d/60-lightdm-gtk-greeter.conf

--- a/src/system/usr/libexec/create-livecd-user.sh
+++ b/src/system/usr/libexec/create-livecd-user.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+USERNAME=livecd
+
+# Check if user already exists
+if ! id "$USERNAME" >/dev/null 2>&1; then
+  echo "Creating $USERNAME user..."
+
+  # Create the user with home directory
+  useradd -m -G wheel -s /bin/bash "$USERNAME"
+
+  # Set no password (auto-login possible)
+  passwd -d "$USERNAME"
+
+  # Allow passwordless sudo
+  echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/90-$USERNAME
+  chmod 0440 /etc/sudoers.d/90-$USERNAME
+else
+  echo "$USERNAME already exists, skipping creation."
+fi

--- a/src/system/usr/libexec/create-livecd-user.sh
+++ b/src/system/usr/libexec/create-livecd-user.sh
@@ -9,8 +9,8 @@ if ! id "$USERNAME" >/dev/null 2>&1; then
   # Create the user with home directory
   useradd -m -G wheel -s /bin/bash "$USERNAME"
 
-  # Set no password (auto-login possible)
-  passwd -d "$USERNAME"
+  # Set password to username
+  echo "$USERNAME" | passwd "$USERNAME" --stdin
 
   # Allow passwordless sudo
   echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/90-$USERNAME


### PR DESCRIPTION
Creates a user called livecd with password livecd that is automatically logged in for SDDM. LightDM support is spotty.

This allows Aurora to boot directly to the desktop
```bash
$ just build ghcr.io/ublue-os/aurora:stable 1
```
![image](https://github.com/user-attachments/assets/c9b128e2-7a0d-473b-8003-5b3fb2bb7832)
