### PR TITLE
fix: add missing shebang for clean recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -152,6 +152,7 @@ build image livesys="0" clean_rootfs="1":
     just iso
 
 clean clean_rootfs="1":
+    #!/usr/bin/env bash
     sudo umount work/rootfs/var/lib/containers/storage/overlay/ || true
     sudo umount work/rootfs/containers/storage/overlay/ || true
     sudo umount work/iso-root/containers/storage/overlay/ || true


### PR DESCRIPTION
This will be interpreted by `/bin/sh` which is not guaranteed to be Bash.