### PR TITLE
chore(rootfs): Make /var/tmp a symlink pointing to /tmp

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,11 @@ rootfs $IMAGE: init-work
     ctr="$(sudo podman create --rm "${IMAGE}")" && trap "sudo podman rm $ctr" EXIT
     sudo podman export $ctr | tar -xf - -C "${ROOTFS}"
 
+    # Make /var/tmp be a tmpfs by symlinking to /tmp,
+    # in order to make bootc work at runtime.
+    rm -r "$ROOTFS"/var/tmp
+    ln -sr "$ROOTFS"/tmp "$ROOTFS"/var/tmp
+
 rootfs-setuid:
     #!/usr/bin/env bash
     set -xeuo pipefail


### PR DESCRIPTION
This is required in order to let bootc run at runtime without podman