### PR TITLE
fix: remove $IMAGE argument from just squash

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -129,7 +129,7 @@ rootfs-install-livesys-scripts: init-work
     systemctl enable livesys.service livesys-late.service
     LIVESYSEOF
 
-squash $IMAGE: init-work
+squash: init-work
     #!/usr/bin/env bash
     set -xeuo pipefail
     ROOTFS="{{ workdir }}/rootfs"
@@ -177,7 +177,7 @@ build image livesys="0" clean_rootfs="1" flatpaks_file="src/flatpaks.example.txt
       just rootfs-install-livesys-scripts
     fi
 
-    just squash "{{ image }}"
+    just squash
     just iso-organize
     just iso
 


### PR DESCRIPTION

This just removes the redundant argument. We dont even use the image on the squash recipe anymore so it should be fine :)