### PR TITLE
feat: add iso building action with rootfs hook

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -254,7 +254,7 @@ clean clean_rootfs="1":
     sudo umount work/rootfs/var/lib/containers/storage/overlay/ || true
     sudo umount work/rootfs/containers/storage/overlay/ || true
     sudo umount work/iso-root/containers/storage/overlay/ || true
-    sudo rm -rf output.iso
+    #sudo rm -rf output.iso
     [ "{{ clean_rootfs }}" == "1" ] && sudo rm -rf {{ workdir }}
 
 vm ISO_FILE *ARGS:

--- a/Justfile
+++ b/Justfile
@@ -22,7 +22,7 @@ initramfs $IMAGE: init-work
     sudo podman run --privileged --rm -i -v .:/app:Z $IMAGE \
         sh <<'INITRAMFSEOF'
     set -xeuo pipefail
-    sudo dnf install -y dracut dracut-live kernel
+    dnf install -y dracut dracut-live kernel
     INSTALLED_KERNEL=$(rpm -q kernel-core --queryformat "%{evr}.%{arch}" | tail -n 1)
     cat >/app/work/fake-uname <<EOF
     #!/usr/bin/env bash
@@ -86,9 +86,9 @@ rootfs-include-flatpaks $FLATPAKS_FILE="src/flatpaks.example.txt":
     sudo podman run --privileged --rm -i -v ".:/app:Z" -v "./${ROOTFS}:/rootfs:Z" registry.fedoraproject.org/fedora:41 \
     <<"LIVESYSEOF"
     set -xeuo pipefail
-    sudo dnf install -y flatpak
-    sudo mkdir -p /etc/flatpak/installations.d /rootfs/var/lib/flatpak
-    sudo tee /etc/flatpak/installations.d/liveiso.conf <<EOF
+    dnf install -y flatpak
+    mkdir -p /etc/flatpak/installations.d /rootfs/var/lib/flatpak
+    tee /etc/flatpak/installations.d/liveiso.conf <<EOF
     [Installation "liveiso"]
     Path=/rootfs/var/lib/flatpak/
     EOF
@@ -150,7 +150,7 @@ squash: init-work
     sudo podman run --privileged --rm -i -v ".:/app:Z" -v "./${ROOTFS}:/rootfs:Z" registry.fedoraproject.org/fedora:41 \
         sh <<"SQUASHEOF"
     set -xeuo pipefail
-    sudo dnf install -y erofs-utils
+    dnf install -y erofs-utils
     mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
     SQUASHEOF
 
@@ -169,7 +169,7 @@ iso:
     sudo podman run --privileged --rm -i -v ".:/app:Z" registry.fedoraproject.org/fedora:41 \
         sh <<"ISOEOF"
     set -xeuo pipefail
-    sudo dnf install -y grub2 grub2-efi grub2-efi-x64-modules grub2-efi-x64-cdboot grub2-efi-x64 grub2-tools-extra xorriso
+    dnf install -y grub2 grub2-efi grub2-efi-x64-modules grub2-efi-x64-cdboot grub2-efi-x64 grub2-tools-extra xorriso
     grub2-mkrescue --xorriso=/app/src/xorriso_wrapper.sh -o /app/output.iso /app/{{ isoroot }}
     ISOEOF
 

--- a/Justfile
+++ b/Justfile
@@ -151,7 +151,7 @@ squash: init-work
         sh <<"SQUASHEOF"
     set -xeuo pipefail
     dnf install -y erofs-utils
-    mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
+    mkfs.erofs -d0 --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
     SQUASHEOF
 
 iso-organize: init-work

--- a/Justfile
+++ b/Justfile
@@ -171,8 +171,8 @@ iso:
     sudo podman run --privileged --rm -i -v ".:/app:Z" registry.fedoraproject.org/fedora:41 \
         sh <<"ISOEOF"
     set -xeuo pipefail
-    ISOROOT=$(realpath {{ isoroot }})
-    WORKDIR=$(realpath {{ workdir }})
+    ISOROOT=$(cd /app && realpath {{ isoroot }})
+    WORKDIR=$(cd /app && realpath {{ workdir }})
     dnf install -y grub2 grub2-efi grub2-efi-x64-modules grub2-efi-x64-cdboot grub2-efi-x64 grub2-tools grub2-tools-extra xorriso shim dosfstools
     mkdir -p $ISOROOT/EFI/BOOT
     cp -avf /boot/efi/EFI/fedora/. $ISOROOT/EFI/BOOT

--- a/Justfile
+++ b/Justfile
@@ -103,7 +103,7 @@ squash-flatpaks $FLATPAKS_FILE="src/flatpaks.example.txt":
     EOF
     flatpak remote-add --installation=liveiso --if-not-exists flathub "https://dl.flathub.org/repo/flathub.flatpakrepo"
     cat /app/{{ FLATPAKS_FILE }} | xargs flatpak install -y --installation=liveiso
-    mkfs.erofs --all-root -zlz4hc,6 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/flatpak.img /app/{{ workdir }}/flatpak
+    mkfs.erofs --quiet --all-root -zlz4hc,6 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/flatpak.img /app/{{ workdir }}/flatpak
     rm -f /etc/flatpak/installations.d/liveiso.conf
     rm -rf /app/{{ workdir }}/flatpak
     LIVESYSEOF

--- a/Justfile
+++ b/Justfile
@@ -75,7 +75,7 @@ squash-container $IMAGE:
     sudo chmod +x "${ROOTFS}/usr/bin/fuse-overlayfs"
     sudo podman run --privileged --rm -i -v ".:/app:Z" registry.fedoraproject.org/fedora:41 \
     sh <<"CONTAINEREOF"
-    sudo dnf install -y erofs-utils
+    dnf install -y erofs-utils
     mkfs.erofs --quiet --all-root -zlz4hc,6 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/container.img /app/{{ workdir }}/containers-storage
     CONTAINEREOF
     sudo umount "{{ workdir }}/containers-storage/overlay"

--- a/Justfile
+++ b/Justfile
@@ -95,9 +95,9 @@ squash-flatpaks $FLATPAKS_FILE="src/flatpaks.example.txt":
     sudo podman run --privileged --rm -i -v ".:/app:Z" registry.fedoraproject.org/fedora:41 \
     <<"LIVESYSEOF"
     set -xeuo pipefail
-    sudo dnf install -y flatpak erofs-utils
-    sudo mkdir -p /etc/flatpak/installations.d /app/{{ workdir }}/flatpak
-    sudo tee /etc/flatpak/installations.d/liveiso.conf <<EOF
+    dnf install -y flatpak erofs-utils
+    mkdir -p /etc/flatpak/installations.d /app/{{ workdir }}/flatpak
+    tee /etc/flatpak/installations.d/liveiso.conf <<EOF
     [Installation "liveiso"]
     Path=/app/{{ workdir }}/flatpak
     EOF
@@ -190,7 +190,7 @@ iso:
     set -x
     ISOROOT=$(realpath /app/{{ isoroot }})
     WORKDIR=$(realpath /app/{{ workdir }})
-    sudo dnf install -y grub2 grub2-efi grub2-efi-x64-modules grub2-efi-x64-cdboot grub2-efi-x64 grub2-tools grub2-tools-extra xorriso shim dosfstools
+    dnf install -y grub2 grub2-efi grub2-efi-x64-modules grub2-efi-x64-cdboot grub2-efi-x64 grub2-tools grub2-tools-extra xorriso shim dosfstools
     mkdir -p $ISOROOT/EFI/BOOT
     cp -avf /boot/efi/EFI/fedora/. $ISOROOT/EFI/BOOT
     cp -avf $ISOROOT/boot/grub/grub.cfg $ISOROOT/EFI/BOOT/BOOT.conf

--- a/Justfile
+++ b/Justfile
@@ -44,7 +44,7 @@ rootfs $IMAGE: init-work
     set -xeuo pipefail
     ROOTFS="{{ workdir }}/rootfs"
     mkdir -p $ROOTFS
-    ctr="$(sudo podman create --rm "${IMAGE}")" && trap "sudo podman rm $ctr" EXIT
+    ctr="$(sudo podman create --rm "${IMAGE}" /usr/bin/bash)" && trap "sudo podman rm $ctr" EXIT
     sudo podman export $ctr | tar -xf - -C "${ROOTFS}"
 
     # Make /var/tmp be a tmpfs by symlinking to /tmp,

--- a/Justfile
+++ b/Justfile
@@ -151,7 +151,7 @@ squash: init-work
         sh <<"SQUASHEOF"
     set -xeuo pipefail
     dnf install -y erofs-utils
-    2> >(grep -vP '^Processing.*' | grep . >&2) mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
+    > >(grep -vP '^Processing.*' | grep .) 2>&1 mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
     SQUASHEOF
 
 iso-organize: init-work

--- a/Justfile
+++ b/Justfile
@@ -258,3 +258,8 @@ container-run-vm ISO_FILE:
     # Run the VM and open the browser to connect
     podman run "${run_args[@]}" &
     xdg-open http://localhost:${port}
+
+# Print the absolute of the files relative to the project dir.
+[private]
+whereis +FILE_PATHS:
+    @realpath -e {{ FILE_PATHS }}

--- a/Justfile
+++ b/Justfile
@@ -178,9 +178,9 @@ build image livesys="0" clean_rootfs="1" flatpaks_file="src/flatpaks.example.txt
     set -xeuo pipefail
 
     # We pass hooks contents with file descriptors:
-    # - 3: hook-post-rootfs
-    unset -v hook-post-rootfs
-    { readarray -d'' -t hook-post-rootfs <&3; } 2>/dev/null || :
+    # - 3: hook_post_rootfs
+    unset -v hook_post_rootfs 2>/dev/null || :
+    { readarray -d'' -t hook_post_rootfs <&3; } 2>/dev/null || :
 
     just clean "{{ clean_rootfs }}"
     just initramfs "{{ image }}"
@@ -195,7 +195,7 @@ build image livesys="0" clean_rootfs="1" flatpaks_file="src/flatpaks.example.txt
 
     # Run hooks
     if [[ -v hook-post-rootfs ]]; then
-      just hook-post-rootfs <<<"$hook-post-rootfs"
+      just hook-post-rootfs <<<"hook_post_rootfs"
     fi
 
     just squash

--- a/Justfile
+++ b/Justfile
@@ -151,7 +151,7 @@ squash: init-work
         sh <<"SQUASHEOF"
     set -xeuo pipefail
     dnf install -y erofs-utils
-    2>(grep -vP '^Processing.*' | grep . >&2) mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
+    2> >(grep -vP '^Processing.*' | grep . >&2) mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
     SQUASHEOF
 
 iso-organize: init-work

--- a/Justfile
+++ b/Justfile
@@ -148,7 +148,7 @@ hook-post-rootfs: init-work
     #!/usr/bin/env bash
     set -xeuo pipefail
     ROOTFS="{{ workdir }}/rootfs"
-    sudo podman run --rm --security-opt label=type:unconfined_t -i --rootfs "$(realpath ${ROOTFS})" /usr/bin/bash \
+    sudo podman run --rm --security-opt label=type:unconfined_t -i -v ".:/app:Z" --rootfs "$(realpath ${ROOTFS})" /usr/bin/bash \
         </dev/stdin
 
 squash: init-work

--- a/Justfile
+++ b/Justfile
@@ -68,7 +68,7 @@ rootfs-include-container $IMAGE:
     # Needs to exist so that we can mount to it
     sudo mkdir -p "${ROOTFS}/var/lib/containers/storage"
     # Remove signatures as signed images get super mad when you do this
-    sudo podman push "${IMAGE}" "containers-storage:[overlay@$(realpath "$ROOTFS")/var/lib/containers/storage]$IMAGE" --remove-signatures
+    sudo podman --transient-store push "${IMAGE}" "containers-storage:[overlay@$(realpath "$ROOTFS")/var/lib/containers/storage]$IMAGE" --remove-signatures
     # We need this in the rootfs specifically so that bootc can know what images are on disk via podman
     sudo curl -fSsLo "${ROOTFS}/usr/bin/fuse-overlayfs" "https://github.com/containers/fuse-overlayfs/releases/download/v1.14/fuse-overlayfs-$(arch)"
     sudo chmod +x "${ROOTFS}/usr/bin/fuse-overlayfs"

--- a/Justfile
+++ b/Justfile
@@ -83,7 +83,7 @@ rootfs-include-flatpaks $FLATPAKS_FILE="src/flatpaks.example.txt":
     ROOTFS="{{ workdir }}/rootfs"
 
     set -xeuo pipefail
-    sudo podman run --privileged --rm -i -v ".:/app:Z" -v "./${ROOTFS}:/rootfs:Z" registry.fedoraproject.org/fedora:41 \
+    sudo podman run --privileged --rm --rmi -i -v ".:/app:Z" -v "./${ROOTFS}:/rootfs:Z" registry.fedoraproject.org/fedora:41 \
     <<"LIVESYSEOF"
     set -xeuo pipefail
     dnf install -y flatpak
@@ -151,7 +151,7 @@ squash: init-work
         sh <<"SQUASHEOF"
     set -xeuo pipefail
     dnf install -y erofs-utils
-    mkfs.erofs -d0 --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
+    2>(grep -vP '^Processing.*' | grep . >&2) mkfs.erofs --all-root -zlz4hc,9 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
     SQUASHEOF
 
 iso-organize: init-work

--- a/Justfile
+++ b/Justfile
@@ -163,7 +163,7 @@ squash: init-work
         sh <<"SQUASHEOF"
     set -xeuo pipefail
     dnf install -y erofs-utils
-    > >(grep -vP '^Processing.*' | grep .) 2>&1 mkfs.erofs --quiet --all-root -zlz4hc,6 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
+    mkfs.erofs --quiet --all-root -zlz4hc,6 -Eall-fragments,fragdedupe=inode -C1048576 /app/{{ workdir }}/squashfs.img /rootfs
     SQUASHEOF
 
 iso-organize: init-work

--- a/Justfile
+++ b/Justfile
@@ -254,7 +254,6 @@ clean clean_rootfs="1":
     sudo umount work/rootfs/var/lib/containers/storage/overlay/ || true
     sudo umount work/rootfs/containers/storage/overlay/ || true
     sudo umount work/iso-root/containers/storage/overlay/ || true
-    #sudo rm -rf output.iso
     [ "{{ clean_rootfs }}" == "1" ] && sudo rm -rf {{ workdir }}
 
 vm ISO_FILE *ARGS:

--- a/action.yml
+++ b/action.yml
@@ -61,3 +61,11 @@ runs:
         cd "${{ github.action_path }}"
         # Cleanup
         sudo PATH="$PATH" $(which just) clean
+        
+    - name: Check the iso is there
+      shell: bash
+      run: |
+        [[ -f $dest ]] || {
+          echo "::error:Iso file does not exist at $dest"
+          exit 1
+        }

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Where the iso will be placed
     required: false
     default: ${{ github.workspace }}/output.iso
+outputs:
+  iso-dest:
+    description: Where the iso was be placed
+    value: ${{ steps.generate-iso.outputs.iso_dest }}
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -29,9 +29,11 @@ runs:
         set -euxo pipefail
         cd "${{ github.action_path }}"
         
+        just=$(whereis just)
+        
         # File descriptors used:
         # - 3: hook-post-rootfs
-        sudo just build "${{ inputs.image-ref }}" \
+        sudo $just build "${{ inputs.image-ref }}" \
           3< <(cat - <<-HOOKPOSTROOTFS
         ${{ inputs.hook-post-rootfs }}
         HOOKPOSTROOTFS)

--- a/action.yml
+++ b/action.yml
@@ -52,4 +52,4 @@ runs:
       run: |
         cd "${{ github.action_path }}"
         # Cleanup
-        sudo just clean
+        sudo $(which just) clean

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         set -euxo pipefail
         cd "${{ github.action_path }}"
         
-        just=$(whereis just)
+        just=$(which just)
         
         # File descriptors used:
         # - 3: hook-post-rootfs

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,8 @@ runs:
         
         # Move iso to iso-dest
         dest="$(realpath --relative-base="${{ github.workspace }}" "${{ inputs.iso-dest }}")"
-        if [[ $(realpath ./output.iso) != $(realpath $dest) ]]; then
+        dest="$(realpath $dest)"
+        if [[ $(realpath ./output.iso) != $dest ]]; then
           mkdir -p "$(dirname "$dest")"
           mv ./output.iso "$dest"
         fi

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,16 @@ runs:
       id: install-just
       uses: extractions/setup-just@v3
 
+    - name: Resolve iso-dest path
+      id: resolve-iso-dest-path
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      run: |
+        set -euxo pipefail
+        d="$(realpath -m --relative-base=. "${{ inputs.iso-dest }}")"
+        d="$(realpath $d)"
+        echo "iso-dest=$d" >> "$GITHUB_OUTPUT"
+
     - name: Generate iso
       id: generate-iso
       shell: bash
@@ -37,7 +47,7 @@ runs:
         
         # File descriptors used:
         # - 3: hook-post-rootfs
-        sudo PATH="$PATH" $just build "${{ inputs.image-ref }}" \
+        sudo PATH="$PATH" just build "${{ inputs.image-ref }}" \
           3< <(cat - <<-HOOKPOSTROOTFS
         ${{ inputs.hook-post-rootfs }}
         HOOKPOSTROOTFS)
@@ -46,14 +56,11 @@ runs:
         sudo chown $(id -u):$(id -g) ./output.iso
         
         # Move iso to iso-dest
-        dest="$(realpath --relative-base="${{ github.workspace }}" "${{ inputs.iso-dest }}")"
-        dest="$(realpath $dest)"
-        if [[ $(realpath ./output.iso) != $dest ]]; then
-          mkdir -p "$(dirname "$dest")"
-          mv ./output.iso "$dest"
-        fi
+        dest="${{ steps.resolve-iso-dest-path.outputs.iso-dest }}"
+        mkdir -p "$(dirname "$dest")"
+        mv -v ./output.iso "$dest" || :
         echo "iso_dest=$dest" >> "$GITHUB_OUTPUT"
-        
+
     - name: Cleanup
       id: titanoboa-cleanup
       shell: bash
@@ -61,7 +68,7 @@ runs:
         cd "${{ github.action_path }}"
         # Cleanup
         sudo PATH="$PATH" $(which just) clean
-        
+
     - name: Check the iso is there
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -26,16 +26,6 @@ runs:
       id: install-just
       uses: extractions/setup-just@v3
 
-    - name: Resolve iso-dest path
-      id: resolve-iso-dest-path
-      shell: bash
-      working-directory: ${{ github.workspace }}
-      run: |
-        set -euxo pipefail
-        d="$(realpath -m --relative-base=. "${{ inputs.iso-dest }}")"
-        d="$(realpath $d)"
-        echo "iso-dest=$d" >> "$GITHUB_OUTPUT"
-
     - name: Generate iso
       id: generate-iso
       shell: bash
@@ -47,7 +37,7 @@ runs:
         
         # File descriptors used:
         # - 3: hook-post-rootfs
-        sudo PATH="$PATH" just build "${{ inputs.image-ref }}" \
+        sudo PATH="$PATH" $just build "${{ inputs.image-ref }}" \
           3< <(cat - <<-HOOKPOSTROOTFS
         ${{ inputs.hook-post-rootfs }}
         HOOKPOSTROOTFS)
@@ -56,11 +46,14 @@ runs:
         sudo chown $(id -u):$(id -g) ./output.iso
         
         # Move iso to iso-dest
-        dest="${{ steps.resolve-iso-dest-path.outputs.iso-dest }}"
-        mkdir -p "$(dirname "$dest")"
-        mv -v ./output.iso "$dest" || :
+        dest="$(realpath --relative-base="${{ github.workspace }}" "${{ inputs.iso-dest }}")"
+        dest="$(realpath $dest)"
+        if [[ $(realpath ./output.iso) != $dest ]]; then
+          mkdir -p "$(dirname "$dest")"
+          mv ./output.iso "$dest"
+        fi
         echo "iso_dest=$dest" >> "$GITHUB_OUTPUT"
-
+        
     - name: Cleanup
       id: titanoboa-cleanup
       shell: bash
@@ -68,7 +61,7 @@ runs:
         cd "${{ github.action_path }}"
         # Cleanup
         sudo PATH="$PATH" $(which just) clean
-
+        
     - name: Check the iso is there
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: >-
   Create LiveCDs of a bootc container image.
   The resulting iso will be placed at `output.iso`.
 inputs:
-  image_ref:
+  image-ref:
     description: Reference to the bootc container image.
     required: true
   hook-post-rootfs:
@@ -32,7 +32,7 @@ runs:
         
         # File descriptors used:
         # - 3: hook-post-rootfs
-        just build \
+        just build "${{ inputs.image-ref }}" \
           3< <(cat - <<-HOOKPOSTROOTFS
         ${{ inputs.hook-post-rootfs }}
         HOOKPOSTROOTFS)

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         
         # File descriptors used:
         # - 3: hook-post-rootfs
-        sudo $just build "${{ inputs.image-ref }}" \
+        sudo PATH="$PATH" $just build "${{ inputs.image-ref }}" \
           3< <(cat - <<-HOOKPOSTROOTFS
         ${{ inputs.hook-post-rootfs }}
         HOOKPOSTROOTFS)
@@ -52,4 +52,4 @@ runs:
       run: |
         cd "${{ github.action_path }}"
         # Cleanup
-        sudo $(which just) clean
+        sudo PATH="$PATH" $(which just) clean

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,41 @@
+name: Titanoboa LiveCD ISO builder
+description: >-
+  Create LiveCDs of a bootc container image.
+  The resulting iso will be placed at `output.iso`.
+inputs:
+  image_ref:
+    description: Reference to the bootc container image.
+    required: true
+  hook-post-rootfs:
+    description: >-
+      Hook ran in the rootfs of the container image before
+      being squashed in `squashfs.img`.
+outputs:
+  iso_path:
+    description: >-
+      Path to the generated iso.
+    value: ${{ steps.generate-iso.outputs.iso_path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install Just
+      id: install-just
+      uses: extractions/setup-just@v3
+
+    - name: Generate iso
+      id: generate-iso
+      shell: bash
+      run: |
+        set -euxo pipefail
+        cd "${{ github.action_path }}"
+        
+        # File descriptors used:
+        # - 3: hook-post-rootfs
+        just build \
+          3< <(cat - <<-HOOKPOSTROOTFS
+        ${{ inputs.hook-post-rootfs }}
+        HOOKPOSTROOTFS)
+        
+        # Output iso path
+        echo "iso_path=$(just whereis output.iso)" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -10,11 +10,10 @@ inputs:
     description: >-
       Hook ran in the rootfs of the container image before
       being squashed in `squashfs.img`.
-outputs:
-  iso_path:
-    description: >-
-      Path to the generated iso.
-    value: ${{ steps.generate-iso.outputs.iso_path }}
+  iso-dest:
+    description: Where the iso will be placed
+    required: false
+    default: ${{ github.workspace }}/output.iso
 
 runs:
   using: composite
@@ -32,10 +31,23 @@ runs:
         
         # File descriptors used:
         # - 3: hook-post-rootfs
-        just build "${{ inputs.image-ref }}" \
+        sudo just build "${{ inputs.image-ref }}" \
           3< <(cat - <<-HOOKPOSTROOTFS
         ${{ inputs.hook-post-rootfs }}
         HOOKPOSTROOTFS)
         
-        # Output iso path
-        echo "iso_path=$(just whereis output.iso)" >> $GITHUB_OUTPUT
+        # Fix iso file permisions
+        sudo chown $(id -u):$(id -g) ./output.iso
+        
+        # Move iso to iso-dest
+        dest="$(realpath --relative-base="${{ github.workspace }}" "${{ inputs.iso-dest }}")"
+        mkdir -p "$(dirname "$dest")"
+        mv ./output.iso "$dest"
+        
+    - name: Cleanup
+      id: titanoboa-cleanup
+      shell: bash
+      run: |
+        cd "${{ github.action_path }}"
+        # Cleanup
+        sudo just clean

--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,11 @@ runs:
         
         # Move iso to iso-dest
         dest="$(realpath --relative-base="${{ github.workspace }}" "${{ inputs.iso-dest }}")"
-        mkdir -p "$(dirname "$dest")"
-        mv ./output.iso "$dest"
+        if [[ $(realpath ./output.iso) != $dest ]]; then
+          mkdir -p "$(dirname "$dest")"
+          mv ./output.iso "$dest"
+        fi
+        echo "iso_dest=$dest" >> "$GITHUB_OUTPUT"
         
     - name: Cleanup
       id: titanoboa-cleanup

--- a/action.yml
+++ b/action.yml
@@ -64,8 +64,10 @@ runs:
         
     - name: Check the iso is there
       shell: bash
+      env:
+        DEST_ISO: ${{ steps.generate-iso.outputs.iso_dest }}
       run: |
-        [[ -f $dest ]] || {
+        [[ -f "${DEST_ISO}" ]] || {
           echo "::error:Iso file does not exist at $dest"
           exit 1
         }

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         
         # Move iso to iso-dest
         dest="$(realpath --relative-base="${{ github.workspace }}" "${{ inputs.iso-dest }}")"
-        if [[ $(realpath ./output.iso) != $dest ]]; then
+        if [[ $(realpath ./output.iso) != $(realpath $dest) ]]; then
           mkdir -p "$(dirname "$dest")"
           mv ./output.iso "$dest"
         fi


### PR DESCRIPTION
Implement reusable action with `hook-post-rootfs` input, allowing users to do customized changes to the rootfs without needing to apply them to the base image (such as placing their bootc installer of choice).

This solves #19 