### PR TITLE
fix: readd fuse-overlayfs so that we can run `podman images` on installers

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -82,6 +82,10 @@ rootfs-include-container $IMAGE:
     # Remove signatures as signed images get super mad when you do this
     sudo "${PODMAN}" push "${IMAGE}" "containers-storage:[overlay@${TARGET_CONTAINERS_STORAGE}]$IMAGE" --remove-signatures
     sudo umount "${TARGET_CONTAINERS_STORAGE}/overlay"
+    # FIXME: add renovate rules for this.
+    # Necessary so `podman images` can run on installers
+    sudo curl -fSsLo "${ROOTFS}/usr/bin/fuse-overlayfs" "https://github.com/containers/fuse-overlayfs/releases/download/v1.14/fuse-overlayfs-$(arch)"
+    sudo chmod +x "${ROOTFS}/usr/bin/fuse-overlayfs"
 
 rootfs-include-flatpaks $FLATPAKS_FILE="src/flatpaks.example.txt":
     #!/usr/bin/env bash


### PR DESCRIPTION

We absolutely need this else podman will complain about the overlay storage driver not working