### PR TITLE
feat: let target installer container image be different from ISO root

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
             image: ghcr.io/ublue-os/bluefin:stable
           - platform: amd64
             image: ghcr.io/ublue-os/bazzite:stable
+            container-image: ghcr.io/ublue-os/bazzite-deck:stable
             livesys: true
           - platform: amd64
             image: ghcr.io/ublue-os/aurora:stable

--- a/Justfile
+++ b/Justfile
@@ -267,10 +267,12 @@ iso:
         $ISOROOT
     ISOEOF
 
-build $image $clean="1" $livesys="0"  $flatpaks_file="src/flatpaks.example.txt" $compression="squashfs":
+build $image $clean="1" $livesys="0"  $flatpaks_file="src/flatpaks.example.txt" $compression="squashfs" $container_image="DEFAULT":
     #!/usr/bin/env bash
     set -xeuo pipefail
-    echo $compression
+    if [ "${container_image}" == "DEFAULT" ] ; then
+        container_image=$image
+    fi
 
     if [ "$clean" == "1" ] ; then
         just clean
@@ -279,7 +281,7 @@ build $image $clean="1" $livesys="0"  $flatpaks_file="src/flatpaks.example.txt" 
     just rootfs "$image"
     just process-grub-template
     just rootfs-setuid
-    just rootfs-include-container "$image"
+    just rootfs-include-container "$container_image"
     just rootfs-include-flatpaks "$flatpaks_file"
 
     if [[ "${livesys}" == "1" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Path to a file with a newline separated flatpak apps list to be installed in the rootfs.
     required: false
     default: none
+  container-image:
+    description: Container image that will be installed onto the target system (can be different from rootfs)
+    required: false
+    default: DEFAULT
 outputs:
   iso-dest:
     description: Where the iso was be placed
@@ -50,6 +54,7 @@ runs:
         ACTION_PATH: ${{ github.action_path }}
         FLATPAKS_LIST: ${{ inputs.flatpaks-list }}
         HOOK_POST_ROOTFS: ${{ inputs.hook-post-rootfs }}
+        CONTAINER_IMAGE: ${{ inputs.container-image }}
       shell: bash
       run: |
         set -euxo pipefail
@@ -62,7 +67,7 @@ runs:
         sudo PATH="$PATH" $just \
           HOOK_post_rootfs="${HOOK_POST_ROOTFS}" \
           build \
-          "${IMAGE_REF}" 1 "${USE_LIVESYS}" "${FLATPAKS_LIST}" "${COMPRESSION}"
+          "${IMAGE_REF}" 1 "${USE_LIVESYS}" "${FLATPAKS_LIST}" "${COMPRESSION}" "${CONTAINER_IMAGE}"
 
         # Fix iso file permisions
         sudo chown $(id -u):$(id -g) ./output.iso


### PR DESCRIPTION

Allows stuff like `bazzite-deck` to be distributed this way
Maybe the wording is a bit ambiguous, would love some suggestions here
Fixes: #42