### PR TITLE
fix: add polkit rules for podman and bootc privileged without password 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           flatpaks-list: ./src/flatpaks.example.txt
           container-image: ${{ matrix.container-image }}
           image-ref: ${{ matrix.image }}
+          add-polkit: "true"
           hook-post-rootfs: ${{ github.workspace }}/.github/workflows/ci_dummy_hook_postrootfs.sh
 
       - name: Upload Output Artifacts

--- a/Justfile
+++ b/Justfile
@@ -87,7 +87,7 @@ rootfs-include-container $IMAGE:
         --root="$(realpath ${ROOTFS}/var/lib/containers/storage)" \
         "${IMAGE}"
     fi
-    sudo umount "${TARGET_CONTAINERS_STORAGE}/overlay"
+    sudo umount "${TARGET_CONTAINERS_STORAGE}/overlay" || true
     # FIXME: add renovate rules for this.
     # Necessary so `podman images` can run on installers
     sudo curl -fSsLo "${ROOTFS}/usr/bin/fuse-overlayfs" "https://github.com/containers/fuse-overlayfs/releases/download/v1.14/fuse-overlayfs-$(arch)"

--- a/Justfile
+++ b/Justfile
@@ -80,8 +80,13 @@ rootfs-include-container $IMAGE:
     sudo mkdir -p "${ROOTFS}/var/lib/containers/storage"
     TARGET_CONTAINERS_STORAGE="$(realpath "$ROOTFS")/var/lib/containers/storage"
     # Remove signatures as signed images get super mad when you do this
-    sudo "${PODMAN}" pull "${IMAGE}"
-    sudo "${PODMAN}" push "${IMAGE}" "containers-storage:[overlay@${TARGET_CONTAINERS_STORAGE}]$IMAGE" --remove-signatures
+    if sudo podman image exists "${IMAGE}" ; then
+        sudo "${PODMAN}" push "${IMAGE}" "containers-storage:[overlay@${TARGET_CONTAINERS_STORAGE}]$IMAGE" --remove-signatures
+    else
+        sudo "${PODMAN}" pull \
+        --root="$(realpath ${ROOTFS}/var/lib/containers/storage)" \
+        "${IMAGE}"
+    fi
     sudo umount "${TARGET_CONTAINERS_STORAGE}/overlay"
     # FIXME: add renovate rules for this.
     # Necessary so `podman images` can run on installers

--- a/Justfile
+++ b/Justfile
@@ -80,6 +80,7 @@ rootfs-include-container $IMAGE:
     sudo mkdir -p "${ROOTFS}/var/lib/containers/storage"
     TARGET_CONTAINERS_STORAGE="$(realpath "$ROOTFS")/var/lib/containers/storage"
     # Remove signatures as signed images get super mad when you do this
+    sudo "${PODMAN}" pull "${IMAGE}"
     sudo "${PODMAN}" push "${IMAGE}" "containers-storage:[overlay@${TARGET_CONTAINERS_STORAGE}]$IMAGE" --remove-signatures
     sudo umount "${TARGET_CONTAINERS_STORAGE}/overlay"
     # FIXME: add renovate rules for this.

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: Container image that will be installed onto the target system (can be different from rootfs)
     required: false
     default: ""
+  add-polkit:
+    description: Add default polkit rules for the container
+    required: false
+    default: "true"
 outputs:
   iso-dest:
     description: Where the iso was be placed
@@ -63,11 +67,12 @@ runs:
         just=$(which just)
 
         USE_LIVESYS=$(echo "${LIVESYS}" | sed -e 's/true/1/g' -e 's/false/0/g')
+        ADD_POLKIT=$(echo "${ADD_POLKIT}" | sed -e 's/true/1/g' -e 's/false/0/g')
 
         sudo PATH="$PATH" $just \
           HOOK_post_rootfs="${HOOK_POST_ROOTFS}" \
           build \
-          "${IMAGE_REF}" 1 "${USE_LIVESYS}" "${FLATPAKS_LIST}" "${COMPRESSION}" "${CONTAINER_IMAGE}"
+          "${IMAGE_REF}" 1 "${USE_LIVESYS}" "${FLATPAKS_LIST}" "${COMPRESSION}" "${CONTAINER_IMAGE}" "${ADD_POLKIT}"
 
         # Fix iso file permisions
         sudo chown $(id -u):$(id -g) ./output.iso

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,7 @@ runs:
         LIVESYS: ${{ inputs.livesys }}
         ACTION_PATH: ${{ github.action_path }}
         FLATPAKS_LIST: ${{ inputs.flatpaks-list }}
+        ADD_POLKIT: ${{ inputs.add-polkit }}
         HOOK_POST_ROOTFS: ${{ inputs.hook-post-rootfs }}
         CONTAINER_IMAGE: ${{ inputs.container-image }}
       shell: bash

--- a/src/polkit-1/rules.d/10-bootc-privileged.rules
+++ b/src/polkit-1/rules.d/10-bootc-privileged.rules
@@ -1,0 +1,12 @@
+polkit.addRule(function(action,subject) {
+    if ( (action.id == "org.freedesktop.policykit.exec") &&
+         (action.lookup("program") == "/usr/bin/bootc") &&
+         (subject.isInGroup("wheel") ) ) {
+      return polkit.Result.YES;
+    }
+
+    return polkit.Result.NOT_HANDLED;
+  }
+);
+
+

--- a/src/polkit-1/rules.d/20-podman-privileged.rules
+++ b/src/polkit-1/rules.d/20-podman-privileged.rules
@@ -1,0 +1,12 @@
+polkit.addRule(function(action,subject) {
+    if ( (action.id == "org.freedesktop.policykit.exec") &&
+         (action.lookup("program") == "/usr/bin/podman") &&
+         (subject.isInGroup("wheel") ) ) {
+      return polkit.Result.YES;
+    }
+
+    return polkit.Result.NOT_HANDLED;
+  }
+);
+
+


### PR DESCRIPTION

Will make our work a lot easier for installers! Just lets `pkexec bootc` and `pkexec podman` run without a password on the live environment

Fixes: #43