### PR TITLE
chore: Use btrfs subvolumes for workdir if possible

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,8 +11,15 @@ HOOK_post_rootfs := ''
 ##########################
 
 init-work:
-    mkdir -p {{ workdir }}
-    mkdir -p {{ isoroot }}
+    #!/usr/bin/env bash
+    if [[ "$(findmnt -no FSTYPE -T "{{ workdir }}" || :)" == btrfs ]]; then
+        if [[ ! -d '{{ workdir }}' ]]; then
+            btrfs subvolume create -p "{{ workdir }}"; } || :
+        fi
+    else
+        mkdir -p "{{ workdir }}"
+    fi
+    mkdir -p "{{ isoroot }}"
 
 initramfs $IMAGE: init-work
     #!/usr/bin/env bash


### PR DESCRIPTION
In order to prevent stuff like btrfs snapshots targeting unnecessary leftovers 