### PR TITLE
feat: use livesys scripts by default for all images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,8 @@ jobs:
           - platform: amd64
             image: ghcr.io/ublue-os/bazzite:stable
             container-image: ghcr.io/ublue-os/bazzite-deck:stable
-            livesys: true
           - platform: amd64
             image: ghcr.io/ublue-os/aurora:stable
-            livesys: true
     steps:
       - name: Maximize Build Space
         if: matrix.platform == 'amd64'

--- a/Justfile
+++ b/Justfile
@@ -283,7 +283,7 @@ iso:
         $ISOROOT
     ISOEOF
 
-build $image $clean="1" $livesys="0" $flatpaks_file="src/flatpaks.example.txt" $compression="squashfs" $container_image="" $polkit="1":
+build $image $clean="1" $livesys="1" $flatpaks_file="src/flatpaks.example.txt" $compression="squashfs" $container_image="" $polkit="1":
     #!/usr/bin/env bash
     set -xeuo pipefail
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   livesys:
     description: Install livesys helpers on the rootfs for the ISO
     required: false
-    default: "false"
+    default: "true"
   compression:
     description: Which type of compression will the ISO will use (erofs (default), or squashfs (smaller sizes, slower read))
     required: false


### PR DESCRIPTION

Honestly having this is much more consistent than having to account specifically for GNOME on some cases. livesys-scripts also make GNOME always launch directly into a live session instead of being annoying and sometimes launching you into that "Try and Install" thing, and sometimes launching you into a regular user creation