### PR TITLE
fix: add default timezone on boot

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -159,6 +159,10 @@ rootfs-install-livesys-scripts: init-work
     # Enable services
     systemctl enable livesys.service livesys-late.service
     LIVESYSEOF
+    install -D -m 0644 src/livesys-session-extra $ROOTFS/usr/share/factory/var/lib/livesys/livesys-session-extra
+    echo "C /var/lib/livesys/livesys-session-extra 0755 root root - /usr/share/factory/var/lib/livesys/livesys-session-extra" > \
+      $ROOTFS/usr/lib/tmpfiles.d/livesys-session-extra.conf
+
 
 # Hook used for custom operations done in the rootfs before it is squashed.
 # Meant to be used in a GH action.

--- a/src/livesys-session-extra
+++ b/src/livesys-session-extra
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+image=$(awk -F= /^ID=/ '{print $2}' /etc/os-release)
+pretty=$(awk -F= /^NAME=/ '{print $2}' /etc/os-release)
+
+usermod -c "$pretty User" liveuser
+hostnamectl hostname "$image"
+
+timedatectl set-timezone America/Chicago


### PR DESCRIPTION
The livesys-scripts package has a feature where you can drop a script into `/var/lib/livesys/livesys-session-extra` and it will run as part of the early boot process that creates the live system user.

This PR adds this script to `/usr/share/factory` on the image and uses tmpfiles.d to make sure it ends up in var.

The script sets the default timezone to America/Chicago (which is arbitrary, I'm open to changing this) and changes the hostname and username to match the image branding.