### PR TITLE
feat: drop-in scripts for livesys-scripts

### DIFF
--- a/src/livesys-session-extra
+++ b/src/livesys-session-extra
@@ -6,3 +6,7 @@ usermod -c "$NAME User" liveuser
 hostnamectl hostname "$ID"
 
 timedatectl set-timezone UTC
+
+if [ -d /var/lib/livesys/livesys-session-extra.d ]; then
+  find /var/lib/livesys/livesys-session-extra.d -type f -exec /bin/bash {} \;
+fi


### PR DESCRIPTION
We are overriding the `/var/lib/livesys/livesys-session-extra` script from the source image. This feature allows images to drop files in `/var/lib/livesys/livesys-session-extra.d` that will be run.

I will use this in Blue95 to change the default username from "Blue95 User" to something else.