### PR TITLE
fix: only pull non-localhost images

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -29,7 +29,7 @@ initramfs $IMAGE: init-work
     {{ _ci_grouping }}
 
     # Pull non-local images
-    [[ "$IMAGE" =~ ^localhost/ ]] || sudo "$PODMAN" pull "$IMAGE"
+    sudo "$PODMAN" image exists "$IMAGE" || sudo "$PODMAN" pull "$IMAGE"
     sudo "${PODMAN}" run --privileged --rm -i -v .:/app:Z $IMAGE \
         sh <<'INITRAMFSEOF'
     set -xeuo pipefail

--- a/Justfile
+++ b/Justfile
@@ -27,7 +27,9 @@ initramfs $IMAGE: init-work
     #!/usr/bin/env bash
     set -xeuo pipefail
     {{ _ci_grouping }}
-    sudo "${PODMAN}" pull $IMAGE
+
+    # Pull non-local images
+    [[ "$IMAGE" =~ ^localhost/ ]] || sudo "$PODMAN" pull "$IMAGE"
     sudo "${PODMAN}" run --privileged --rm -i -v .:/app:Z $IMAGE \
         sh <<'INITRAMFSEOF'
     set -xeuo pipefail


### PR DESCRIPTION
Trying to pull a locally built image like `localhost/aurora:latest` fails. This guard skips the pull in this case.