### PR TITLE
feat: initial install of readymade

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -145,6 +145,36 @@ rootfs-include-polkit: init-work
     ROOTFS="{{ workdir }}/rootfs"
     install -Dpm0644 -t "${ROOTFS}/etc/polkit-1/rules.d/" ./src/polkit-1/rules.d/*.rules
 
+rootfs-setup-readymade: init-work
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    {{ _ci_grouping }}
+    ROOTFS="{{ workdir }}/rootfs"
+    install -D -m 0644 ./src/readymade.toml "${ROOTFS}/etc/readymade.toml"
+    sudo "${PODMAN}" run --security-opt label=type:unconfined_t -i --rootfs "$(realpath ${ROOTFS})" /usr/bin/bash \
+    <<"READYMADEEOF"
+    set -xeuo pipefail
+    dnf="$({ which dnf5 || which dnf; } 2>/dev/null)"
+
+    # Install Terra repo
+    RHEL_VER="$(rpm -E %{?rhel})"
+    FEDORA_VER="$(rpm -E %{?fedora})"
+
+    VER=""
+    if [[ -n "$RHEL_VER" ]]; then
+        VER="el$RHEL_VER"
+    elif [[ -n "$FEDORA_VER" ]]; then
+        VER="$FEDORA_VER"
+    else
+        echo "OS version not supported"
+        exit 1
+    fi
+
+    $dnf install -y --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$VER' terra-release
+
+    $dnf install -y readymade
+    READYMADEEOF
+
 rootfs-install-livesys-scripts: init-work
     #!/usr/bin/env bash
     set -xeuo pipefail
@@ -327,6 +357,7 @@ build $image $clean="1" $livesys="1" $flatpaks_file="src/flatpaks.example.txt" $
     just rootfs "$image"
     just process-grub-template
     just rootfs-setuid
+    just rootfs-setup-readymade
     just rootfs-include-container "$container_image"
 
     # Scrap container_image once we dont need it

--- a/src/readymade.toml
+++ b/src/readymade.toml
@@ -1,0 +1,8 @@
+[distro]
+# TODO: make this configurable from the github action
+name = "Universal Blue"
+icon = "fedora-logo-icon" # optional
+
+[install]
+allowed_installtypes = ["chromebookinstall", "wholedisk", "dualboot", "custom"]
+copy_mode = "bootc"


### PR DESCRIPTION
Initial work for installing readymade onto the image (from terra). Currently readymade isn't available for centos 10 due to dependency issues (https://github.com/terrapkg/packages/pull/4299) so this doesn't work with bluefin LTS.