### PR TITLE
fix: set /etc/localtime so KDE Plasma has a clock

### DIFF
--- a/src/livesys-session-extra
+++ b/src/livesys-session-extra
@@ -6,6 +6,7 @@ usermod -c "$NAME User" liveuser
 hostnamectl hostname "$ID"
 
 timedatectl set-timezone UTC
+ln -s /usr/share/zoneinfo/UTC /etc/localtime
 
 if [ -d /var/lib/livesys/livesys-session-extra.d ]; then
   find /var/lib/livesys/livesys-session-extra.d -type f -exec /bin/bash {} \;


### PR DESCRIPTION
fixes this here

![image](https://github.com/user-attachments/assets/f7fd0ebb-adb9-4248-88c5-ff14e436c5eb)

KDE checks for `/etc/localtime` and seemingly doesn't care about anything else like `timedatectl` so this didn't work https://github.com/ublue-os/titanoboa/pull/60