### PR TITLE
chore: pin dependency action to hash

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
   steps:
     - name: Install Just
       id: install-just
-      uses: extractions/setup-just@v3
+      uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
     - name: Generate iso
       id: generate-iso


### PR DESCRIPTION
As recommended by https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions