### PR TITLE
chore: use 'titanoboa_boot' as partition name

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -392,7 +392,7 @@ iso:
 
     xorrisofs \
         -R \
-        -V bluefin_boot \
+        -V titanoboa_boot \
         -partition_offset 16 \
         -appended_part_as_gpt \
         -append_partition 2 C12A7328-F81F-11D2-BA4B-00A0C93EC93B \

--- a/src/grub.cfg.tmpl
+++ b/src/grub.cfg.tmpl
@@ -12,20 +12,20 @@ insmod chain
 
 set timeout=10
 
-search --no-floppy --set=root -l 'bluefin_boot'
+search --no-floppy --set=root -l 'titanoboa_boot'
 
 menuentry 'Try @PRETTY_NAME@' --class fedora --class gnu-linux --class gnu --class os {
-  linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=bluefin_boot enforcing=0 rd.live.image @EXTRA_KARGS@
+  linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=titanoboa_boot enforcing=0 rd.live.image @EXTRA_KARGS@
   initrd ($root)/boot/initramfs.img
 }
 
 # menuentry 'Try @PRETTY_NAME@ (RAM Only)' --class fedora --class gnu-linux --class gnu --class os {
-#   linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=bluefin_boot enforcing=0 rd.live.ram rd.live.image @EXTRA_KARGS@
+#   linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=titanoboa_boot enforcing=0 rd.live.ram rd.live.image @EXTRA_KARGS@
 #   initrd ($root)/boot/initramfs.img
 # }
 # submenu 'Troubleshooting -->' {
 #   menuentry 'Install @PRETTY_NAME@ in basic graphics mode' --class fedora --class gnu-linux --class gnu --class os {
-#     linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=bluefin_boot enforcing=0 rd.live.image nomodeset
+#     linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=titanoboa_boot enforcing=0 rd.live.image nomodeset
 #     initrd ($root)/boot/initramfs.img
 #   }
 # }


### PR DESCRIPTION
'bluefin_boot' was an old placeholder name. Using a more generic name seems more adecuate, as now we use titanoboa across all our isos.