### PR TITLE
chore: Rename bootup entry in grub

### DIFF
--- a/src/grub.cfg.tmpl
+++ b/src/grub.cfg.tmpl
@@ -14,7 +14,7 @@ set timeout=10
 
 search --no-floppy --set=root -l 'titanoboa_boot'
 
-menuentry 'Bootup @PRETTY_NAME@ Live ISO' --class fedora --class gnu-linux --class gnu --class os {
+menuentry '@PRETTY_NAME@ Live ISO' --class fedora --class gnu-linux --class gnu --class os {
   linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=titanoboa_boot enforcing=0 rd.live.image @EXTRA_KARGS@
   initrd ($root)/boot/initramfs.img
 }

--- a/src/grub.cfg.tmpl
+++ b/src/grub.cfg.tmpl
@@ -14,7 +14,7 @@ set timeout=10
 
 search --no-floppy --set=root -l 'titanoboa_boot'
 
-menuentry 'Try @PRETTY_NAME@' --class fedora --class gnu-linux --class gnu --class os {
+menuentry 'Bootup @PRETTY_NAME@ Live ISO' --class fedora --class gnu-linux --class gnu --class os {
   linux ($root)/boot/vmlinuz quiet rhgb root=live:CDLABEL=titanoboa_boot enforcing=0 rd.live.image @EXTRA_KARGS@
   initrd ($root)/boot/initramfs.img
 }


### PR DESCRIPTION
'Try OS_NAME' might give the wrong impression that the live ISO
environment fully mirrors a full install.