### PR TITLE
fix: pass mksquashfs exclude list last so -comp zstd is honored

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -13,7 +13,7 @@ mkdir -p \
 cd /work || exit 1
 
 # Create the squashfs image of the container image
-mksquashfs /rootfs /work/iso-root/LiveOS/squashfs.img -all-root -noappend -e sysroot -e ostree -comp zstd -Xcompression-level 19
+mksquashfs /rootfs /work/iso-root/LiveOS/squashfs.img -all-root -noappend -comp zstd -Xcompression-level 19 -e sysroot ostree
 
 iso_config_file=/rootfs/usr/lib/bootc-image-builder/iso.yaml
 if [[ ! -f $iso_config_file ]]; then


### PR DESCRIPTION
While debugging why my Titanoboa-built ISOs came out larger than expected, I noticed the build log says:

```
Creating 4.0 filesystem ... gzip compressed
```

even though build_iso.sh asks for `-comp zstd -Xcompression-level 19`. Turns out mksquashfs treats everything after the first `-e` as exclude names, so the compressor options get swallowed as (nonexistent) excludes and it silently falls back to gzip.

Fix: move the compressor options before `-e` and pass both excludes to a single `-e` (the man page says it has to be the last option).

Tested locally with squashfs-tools 4.6.1: zstd is applied, sysroot and ostree are still excluded. Should shrink ISOs and speed up live boot reads for every consumer.