### PR TITLE
grub2: support a raw extra_cfg fragment in the iso config

### DIFF
--- a/build_iso.sh
+++ b/build_iso.sh
@@ -68,6 +68,21 @@ menuentry '$entry_name' {
 EOF
 done
 
+# Optional raw grub.cfg fragment appended after the generated entries.
+# Lets images add entries the name/linux/initrd schema cannot express,
+# e.g. chainloading MokManager so Secure Boot users can enroll the
+# image's signing key directly from the boot menu:
+#
+#   grub2:
+#     extra_cfg: |
+#       menuentry 'Enroll Secure Boot key' {
+#         chainloader /EFI/BOOT/mmx64.efi
+#       }
+extra_cfg=$(yq -r '.grub2.extra_cfg // ""' <"$iso_config_file")
+if [ -n "$extra_cfg" ]; then
+    grub_cfg+=$'\n'"$extra_cfg"
+fi
+
 for dir in /work/EFI/* /work/iso-root/boot/grub2; do
     echo "$grub_cfg" >"$dir/grub.cfg"
 done


### PR DESCRIPTION
The generated grub.cfg only knows the name/linux/initrd entry shape. That makes it impossible to add entries like a MokManager chainload, which Secure Boot users need when the image ships a custom-signed kernel: shim rejects the live kernel until the signing key is enrolled, and there's no way to reach MokManager from the menu.

This adds an optional `grub2.extra_cfg` string that gets appended verbatim after the generated entries:

```yaml
grub2:
  extra_cfg: |
    menuentry 'Enroll Secure Boot key' {
      chainloader /EFI/fedora/mmx64.efi
    }
```

`insmod chain` is already in the preamble so chainloader entries work as-is. No behavior change when the key is absent.

Context for the use case, observed on a margine ISO in a q35 OVMF VM with Secure Boot enabled: GRUB's shim_lock rejects the custom-signed kernel ("bad shim signature") and drops back to the menu — MokManager never launches on its own, so without an entry like this the only way to enroll is a manual `chainloader` from the GRUB console.